### PR TITLE
Add cross-compilation support for Linux RISC-V 64

### DIFF
--- a/script/build.py
+++ b/script/build.py
@@ -9,6 +9,7 @@ def main():
   machine = common.machine()
   system = common.system()
   ndk = common.ndk()
+  gcc_version = common.gcc_version()
 
   if build_type == 'Debug':
     args = ['is_debug=true']
@@ -54,16 +55,17 @@ def main():
       'extra_cflags_cc=["-frtti"]',
     ]
 
-    if (machine == 'arm64') and (machine != common.native_machine()):
+    target_triplet = common.target_triplet()
+    if (machine == common.native_machine()) or (target_triplet == ''):
       args += [
-        'cc="aarch64-linux-gnu-gcc-9"',
-        'cxx="aarch64-linux-gnu-g++-9"',
-        'extra_cflags=["-I/usr/aarch64-linux-gnu/include"]'
+        f'cc="gcc-{gcc_version}"',
+        f'cxx="g++-{gcc_version}"'
       ]
     else:
       args += [
-        'cc="gcc-9"',
-        'cxx="g++-9"',
+        f'cc="{target_triplet}-gcc-{gcc_version}"',
+        f'cxx="{target_triplet}-g++-{gcc_version}"',
+        f'extra_cflags=["-I/usr/{target_triplet}/include"]'
       ]
 
   elif 'windows' == system:

--- a/script/common.py
+++ b/script/common.py
@@ -10,6 +10,7 @@ def create_parser(version_required=False):
   parser.add_argument('--system')
   parser.add_argument('--machine')
   parser.add_argument('--ndk')
+  parser.add_argument('--gcc-version', default='9')
   return parser
 
 def system():
@@ -18,12 +19,26 @@ def system():
   return args.system if args.system else {'Darwin': 'macos', 'Linux': 'linux', 'Windows': 'windows'}[platform.system()]
 
 def native_machine():
-  return {'AMD64': 'x64', 'x86_64': 'x64', 'arm64': 'arm64'}[platform.machine()]
+  return {
+    'AMD64': 'x64', 'x86_64': 'x64',
+    'arm64': 'arm64', 'aarch64': 'arm64',
+    'riscv64': 'riscv64'
+  }[platform.machine()]
 
 def machine():
   parser = create_parser()
   (args, _) = parser.parse_known_args()
   return args.machine if args.machine else native_machine()
+
+def target_triplet():
+  if (system() == 'linux'):
+    return {
+      'x64': 'x86_64-linux-gnu',
+      'arm64': 'aarch64-linux-gnu',
+      'riscv64': 'riscv64-linux-gnu'
+    }.get(machine(), '')
+  else:
+    return ''
 
 def version():
   parser = create_parser()
@@ -62,3 +77,8 @@ def ndk():
   parser = create_parser()
   (args, _) = parser.parse_known_args()
   return args.ndk if args.ndk else ''
+
+def gcc_version():
+  parser = create_parser()
+  (args, _) = parser.parse_known_args()
+  return args.gcc_version


### PR DESCRIPTION
Unfortunately, using riscv64-linux-gnu-gcc-9 or 10 to compile Skia can cause internal compiler errors, so I am currently unable to use GitHub Action to build for RISC-V 64.