### PR TITLE
Add runtime control for SK_FONT_HOST_USE_SYSTEM_SETTINGS

### DIFF
--- a/patches/ext_SkTypeface_win_dw.patch
+++ b/patches/ext_SkTypeface_win_dw.patch
@@ -1,0 +1,59 @@
+diff --git a/src/ports/SkTypeface_win_dw.cpp b/src/ports/SkTypeface_win_dw.cpp
+index b9d69ab303204b68f97a1cae3bafbb1f77f0ac67..e434abba3b0c75dff4a48600e34c91ac6e9d766a 100644
+--- a/src/ports/SkTypeface_win_dw.cpp
++++ b/src/ports/SkTypeface_win_dw.cpp
+@@ -543,6 +543,12 @@ std::unique_ptr<SkScalerContext> DWriteFontTypeface::onCreateScalerContext(
+             sk_ref_sp(const_cast<DWriteFontTypeface*>(this)), effects, desc);
+ }
+ 
++static std::atomic<int> gUseSystemRenderingParams{-1};
++
++extern "C" void DWriteTypeface_UseSystemRenderingParams(int value) {
++    gUseSystemRenderingParams.store(value);
++}
++
+ void DWriteFontTypeface::onFilterRec(SkScalerContextRec* rec) const {
+     if (rec->fFlags & SkScalerContext::kLCD_Vertical_Flag) {
+         rec->fMaskFormat = SkMask::kA8_Format;
+@@ -561,19 +567,31 @@ void DWriteFontTypeface::onFilterRec(SkScalerContextRec* rec) const {
+     }
+     rec->setHinting(h);
+ 
++    int setting = gUseSystemRenderingParams.load();
++    bool useSystem;
++    if (setting == -1) {
+ #if defined(SK_FONT_HOST_USE_SYSTEM_SETTINGS)
+-    IDWriteFactory* factory = sk_get_dwrite_factory();
+-    if (factory != nullptr) {
+-        SkTScopedComPtr<IDWriteRenderingParams> defaultRenderingParams;
+-        if (SUCCEEDED(factory->CreateRenderingParams(&defaultRenderingParams))) {
+-            float gamma = defaultRenderingParams->GetGamma();
+-            rec->setDeviceGamma(gamma);
+-            rec->setPaintGamma(gamma);
+-
+-            rec->setContrast(defaultRenderingParams->GetEnhancedContrast());
++        useSystem = true;
++#else
++        useSystem = false;
++#endif
++    } else {
++        useSystem = (setting == 1);
++    }
++
++    if (useSystem) {
++        IDWriteFactory* factory = sk_get_dwrite_factory();
++        if (factory != nullptr) {
++            SkTScopedComPtr<IDWriteRenderingParams> defaultRenderingParams;
++            if (SUCCEEDED(factory->CreateRenderingParams(&defaultRenderingParams))) {
++                float gamma = defaultRenderingParams->GetGamma();
++                rec->setDeviceGamma(gamma);
++                rec->setPaintGamma(gamma);
++
++                rec->setContrast(defaultRenderingParams->GetEnhancedContrast());
++            }
+         }
+     }
+-#endif
+ }
+ 
+ ///////////////////////////////////////////////////////////////////////////////

--- a/script/build.py
+++ b/script/build.py
@@ -47,7 +47,7 @@ def main():
       args += ['extra_cflags=["-stdlib=libc++", "-mmacosx-version-min=10.13"]']
   elif 'linux' == system:
     args += [
-      'skia_use_system_freetype2=false',
+      'skia_use_system_freetype2=true',
       # 'skia_enable_gpu=true',
       'extra_cflags_cc=["-frtti"]',
       'skia_use_egl=true',

--- a/script/build.py
+++ b/script/build.py
@@ -70,7 +70,7 @@ def main():
       'skia_use_system_freetype2=false',
       # 'skia_use_angle=true',
       'skia_use_direct3d=true',
-      #'extra_cflags=["-DSK_FONT_HOST_USE_SYSTEM_SETTINGS"]',
+      'extra_cflags=["-DSK_FONT_HOST_USE_SYSTEM_SETTINGS"]',
     ]
   elif 'android' == system:
     args += [

--- a/script/build.py
+++ b/script/build.py
@@ -47,7 +47,7 @@ def main():
       args += ['extra_cflags=["-stdlib=libc++", "-mmacosx-version-min=10.13"]']
   elif 'linux' == system:
     args += [
-      'skia_use_system_freetype2=true',
+      'skia_use_system_freetype2=false',
       # 'skia_enable_gpu=true',
       'extra_cflags_cc=["-frtti"]',
       'skia_use_egl=true',
@@ -70,7 +70,7 @@ def main():
       'skia_use_system_freetype2=false',
       # 'skia_use_angle=true',
       'skia_use_direct3d=true',
-      'extra_cflags=["-DSK_FONT_HOST_USE_SYSTEM_SETTINGS"]',
+      #'extra_cflags=["-DSK_FONT_HOST_USE_SYSTEM_SETTINGS"]',
     ]
   elif 'android' == system:
     args += [


### PR DESCRIPTION
### Problem

When `SK_FONT_HOST_USE_SYSTEM_SETTINGS` is defined at compile time, Skia reads
gamma and contrast from Windows ClearType settings via DirectWrite API. While this
makes text match native Windows rendering, it introduces two issues:

- **Cross-wrapper inconsistency**: apps combining Skija with other Skia wrappers
  (e.g. SkiaSharp) that are built without this flag will produce visually different
  text on the same machine
- **Machine-dependent visual testing**: pixel-level regression tests may pass on
  one machine and fail on another due to different ClearType settings

### Solution

Instead of removing `SK_FONT_HOST_USE_SYSTEM_SETTINGS` (which would change the
default behavior), this PR exposes it as a runtime option via a small patch to
`SkTypeface_win_dw.cpp`:
```cpp
// -1 = follow compile-time default (SK_FONT_HOST_USE_SYSTEM_SETTINGS)
//  0 = force off (consistent, machine-independent rendering)
//  1 = force on (match Windows native rendering)
static std::atomic gUseSystemRenderingParams{-1};
```

This preserves the existing default behavior while allowing callers to opt out
when needed.

### Testing

Verified pixel-level output matches SkiaSharp on the same machine after removing the flag.
<img width="200" height="100" alt="text_JAVA_Skija" src="https://github.com/user-attachments/assets/a68e6a4b-d7a3-44a9-8d77-0b3b7e07f293" />
<img width="200" height="100" alt="text_NET - SkiaSharp" src="https://github.com/user-attachments/assets/3befb399-56aa-46db-9fca-83e19312bb96" />


**Below is an outdated attempt at a solution**

---

_Remove `SK_FONT_HOST_USE_SYSTEM_SETTINGS` flag on Windows_

_Problem_

Text rendered via Skija produces slightly different antialiasing compared to other Skia wrappers (e.g. SkiaSharp) even when using the same Skia version (m119), same font, same size, and same paint settings. The difference is visible at the pixel color level in subpixel intensity of glyph edges.

_Root Cause_

The Windows build configuration included `-DSK_FONT_HOST_USE_SYSTEM_SETTINGS` in `extra_cflags`. When this flag is defined, Skia reads gamma and contrast values from the system via the DirectWrite API (`IDWriteRenderingParams`):
```cpp
// SkTypeface_win_dw.cpp
#if defined(SK_FONT_HOST_USE_SYSTEM_SETTINGS)
    factory->CreateRenderingParams(&defaultRenderingParams);
    rec->setDeviceGamma(defaultRenderingParams->GetGamma());         // e.g. 1.8
    rec->setContrast(defaultRenderingParams->GetEnhancedContrast()); // e.g. 0.5
#endif
```

Without this flag, Skia uses its own hardcoded defaults (gamma ~1.4), which is consistent with the behavior of other wrappers and produces identical rendering across environments regardless of per-machine Windows ClearType settings.

_Effect of the flag_

| Setting | With flag | Without flag |
|---------|-----------|--------------|
| Gamma source | DirectWrite system params | Skia hardcoded default (~1.4) |
| Rendering | Varies per machine | Consistent across machines |
| Cross-wrapper consistency | ✗ | ✓ |

_Change_

Removed `-DSK_FONT_HOST_USE_SYSTEM_SETTINGS` from Windows build args in `script/build.py`.
