### PR TITLE
Build for Windows Arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,32 +79,38 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   windows:
-    runs-on: windows-latest
     strategy:
       matrix:
-        build_type: [Release, Debug]
+        os: [ windows-latest, windows-11-arm ]
+        build_type: [ Release, Debug ]
       fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - shell: bash
         run: python3 script/check_release.py --version ${{ env.version }} --build-type ${{ matrix.build_type }}
         if: ${{ github.event.inputs.skip_release != 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: abdes/gha-setup-ninja@660f330a40aefa8d11632b3f901e92a4adb33d65
-      - uses: microsoft/setup-msbuild@v1
+      - run: |
+          ninja --version
+          $os_arch = "${{ runner.arch }}".ToLower()
+          echo "os_arch=$os_arch" >> $env:GITHUB_ENV
+      - uses: microsoft/setup-msbuild@v3
+        with:
+          msbuild-architecture: ${{ env.os_arch }}
       - uses: ilammy/msvc-dev-cmd@v1
         with:
-          arch: amd64
+          arch: ${{ env.os_arch }}
       - shell: bash
         run: python3 script/checkout.py --version ${{ env.version }}
       - shell: bash
         run: python3 script/build.py --build-type ${{ matrix.build_type }}
       - shell: bash
         run: python3 script/archive.py --version ${{ env.version }} --build-type ${{ matrix.build_type }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
-          name: Skia-${{ env.version }}-windows-${{ matrix.build_type }}-x64.zip
+          name: Skia-${{ env.version }}-windows-${{ matrix.build_type }}-${{ env.os_arch }}.zip
           path: '*.zip'
       - shell: bash
         run: python3 script/release.py --version ${{ env.version }} --build-type ${{ matrix.build_type }}

--- a/patches/fetch-gn_for_win_arm64.patch
+++ b/patches/fetch-gn_for_win_arm64.patch
@@ -1,0 +1,14 @@
+diff --git a/bin/fetch-gn b/bin/fetch-gn
+index ebdc31c449..c727f342b6 100755
+--- a/bin/fetch-gn
++++ b/bin/fetch-gn
+@@ -21,6 +21,9 @@ gnzip = os.path.join(tempfile.mkdtemp(), 'gn.zip')
+ with open(gnzip, 'wb') as f:
+   OS  = {'darwin': 'mac', 'linux': 'linux', 'linux2': 'linux', 'win32': 'windows'}[sys.platform]
+   cpu = {'aarch64': 'arm64', 'amd64': 'amd64', 'arm64': 'arm64', 'x86_64': 'amd64'}[platform.machine().lower()]
++  if (OS == 'windows') and (cpu == 'arm64'):
++    # for Windows Arm64, force the use of the amd64 gn binary
++    cpu = 'amd64'
+ 
+   rev = 'b2afae122eeb6ce09c52d63f67dc53fc517dbdc8'
+   url = 'https://chrome-infra-packages.appspot.com/dl/gn/gn/{}-{}/+/git_revision:{}'.format(

--- a/script/common.py
+++ b/script/common.py
@@ -20,7 +20,7 @@ def system():
   return args.system if args.system else {'Darwin': 'macos', 'Linux': 'linux', 'Windows': 'windows'}[platform.system()]
 
 def native_machine():
-  return {'AMD64': 'x64', 'x86_64': 'x64', 'arm64': 'arm64'}[platform.machine()]
+  return {'amd64': 'x64', 'x86_64': 'x64', 'arm64': 'arm64'}[platform.machine().lower()]
 
 def machine():
   parser = create_parser()


### PR DESCRIPTION
Adding new build for Windows Arm64 in the GitHub action workflow `build.yml`, with a patch file for `skia's bin/fetch-gn` script to use/download the official `gn` binary for amd64 when building for Windows Arm64 platform. This patch is needed because there's no official `gn` binary for Windows Arm64 in the chrome's appspot store, plus Windows Arm64 can run the amd64 binary successfully using x64 emulation.